### PR TITLE
Fix fallback for MCP server

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,44 +1,50 @@
 import json
 from pathlib import Path
 from typing import List, Dict
+import sys
 
 from bm25_retrieval import BM25Retriever, load_index, load_corpus
 
 
-class FastMCP:
-    """Minimal FastMCP-like server for demonstration."""
+try:
+    # Use the real FastMCP implementation if available so that the MCP
+    # CLI can recognize this server object.
+    from mcp.server.fastmcp.server import FastMCP as MCPServer
+except Exception:  # pragma: no cover - optional dependency
+    class MCPServer:
+        """Minimal FastMCP-like server for demonstration."""
 
-    def __init__(self, name: str):
-        self.name = name
-        self._tools: Dict[str, callable] = {}
+        def __init__(self, name: str):
+            self.name = name
+            self._tools: Dict[str, callable] = {}
 
-    def tool(self, name: str | None = None):
-        def decorator(func):
-            self._tools[name or func.__name__] = func
-            return func
+        def tool(self, name: str | None = None):
+            def decorator(func):
+                self._tools[name or func.__name__] = func
+                return func
 
-        return decorator
+            return decorator
 
-    def run(self, transport: str = "stdio"):
-        if transport != "stdio":
-            raise ValueError("Only stdio transport is supported in this demo")
-        print(f"{self.name} server ready", flush=True)
-        for line in sys.stdin:
-            try:
-                req = json.loads(line)
-                tool = req.get("tool")
-                args = req.get("args", {})
-                if tool not in self._tools:
-                    resp = {"error": f"unknown tool: {tool}"}
-                else:
-                    result = self._tools[tool](**args)
-                    resp = {"result": result}
-            except Exception as e:
-                resp = {"error": str(e)}
-            print(json.dumps(resp), flush=True)
+        def run(self, transport: str = "stdio"):
+            if transport != "stdio":
+                raise ValueError("Only stdio transport is supported in this demo")
+            print(f"{self.name} server ready", flush=True)
+            for line in sys.stdin:
+                try:
+                    req = json.loads(line)
+                    tool = req.get("tool")
+                    args = req.get("args", {})
+                    if tool not in self._tools:
+                        resp = {"error": f"unknown tool: {tool}"}
+                    else:
+                        result = self._tools[tool](**args)
+                        resp = {"result": result}
+                except Exception as e:
+                    resp = {"error": str(e)}
+                print(json.dumps(resp), flush=True)
 
 
-mcp = FastMCP("q2d_search")
+mcp = MCPServer("q2d_search")
 
 # Preload index and corpus for the fraud dataset
 _INDEX_PATH = Path(__file__).with_name("fraud_index.json")
@@ -65,6 +71,4 @@ def search(query: str, top_k: int = 5) -> List[Dict[str, object]]:
 
 
 if __name__ == "__main__":
-    import sys
-
     mcp.run(transport="stdio")


### PR DESCRIPTION
## Summary
- use real `FastMCP` from `mcp` when available
- add a minimal fallback implementation
- always import `sys` for runtime

## Testing
- `pytest -q`
- `python -m py_compile mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6849585a4c94832497cfd1d995bf77bc