### PR TITLE
Add fraud data loader tool

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -4,6 +4,7 @@ from typing import List, Dict
 import sys
 
 from bm25_retrieval import BM25Retriever, load_index, load_corpus
+from score import load_qrels, compute_scores
 
 
 try:
@@ -52,6 +53,21 @@ _CORPUS_DIR = Path("data") / "fraud"
 _INDEX = load_index(_INDEX_PATH)
 _BM25 = BM25Retriever(_INDEX)
 _DOCS = {doc["id"]: doc["text"] for doc in load_corpus(str(_CORPUS_DIR))}
+_QUERIES_PATH = _CORPUS_DIR / "format" / "queries.json"
+_QRELS_PATH = _CORPUS_DIR / "format" / "qrels.json"
+
+with open(_QUERIES_PATH, "r", encoding="utf-8") as f:
+    _QUERIES = json.load(f)
+
+_QRELS = load_qrels(str(_QRELS_PATH))
+
+
+@mcp.tool()
+def read_fraud_data() -> List[Dict[str, object]]:
+    """Return the fraud judgment summary dataset."""
+    path = _CORPUS_DIR / "fraud_judgment_summary.json"
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 @mcp.tool()
@@ -68,6 +84,17 @@ def search(query: str, top_k: int = 5) -> List[Dict[str, object]]:
         {"doc_id": doc_id, "score": score, "text": _DOCS.get(doc_id, "")}
         for score, doc_id in results
     ]
+
+
+@mcp.tool()
+def evaluate_fraud(top_k: int = 10) -> Dict[str, float]:
+    """Run BM25 on fraud queries and return average scores."""
+    preds = {}
+    for q in _QUERIES:
+        res = _BM25.query(q["text"], top_k)
+        preds[q["id"]] = [doc_id for score, doc_id in res]
+    accuracy, mrr = compute_scores(_QRELS, preds)
+    return {"accuracy": accuracy, "mrr": mrr}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expose fraud judgment summaries via `read_fraud_data` tool

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from mcp_server import read_fraud_data, evaluate_fraud
print(len(read_fraud_data()))
print(evaluate_fraud())
PY`
- `python evaluate_bm25.py --top_k 1 | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_684beac4233c83248273a877a2db9e14