### PR TITLE
Add pagination to read_fraud_data tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ uv pip install -r requirements.txt
 預設使用 `gemini-2.0-flash` 模型。建議先使用 `search` 觀察檢索結果，
 若結果不足再呼叫 `expand_search`。呼叫時需提供 `query` 與可選的 `top_k` 參數。
 
+此外，`read_fraud_data` 工具現在支援 `offset` 與 `limit` 參數，可分批取回資料以避免
+一次回傳過多內容造成解析問題。例如：
+
+```bash
+{"tool": "read_fraud_data", "args": {"offset": 0, "limit": 20}}
+```
+
 ## Gemini MCP 客戶端
 
 若要使用 `gemini_mcp_client.py` 啟動智能助手，請先設定 Google Gemini API 金鑰。建議在專案根目錄建立 `.env` 檔並填入：

--- a/gemini_mcp_client.py
+++ b/gemini_mcp_client.py
@@ -129,8 +129,11 @@ class GeminiMCPAgent:
                 }
             },
             "read_fraud_data": {
-                "description": "讀取完整的詐欺判決摘要資料集",
-                "parameters": {}
+                "description": "讀取詐欺判決摘要資料集，可指定 offset 與 limit",
+                "parameters": {
+                    "offset": "起始索引，預設 0",
+                    "limit": "最多返回的筆數，預設為全部"
+                }
             },
             "evaluate_fraud": {
                 "description": "評估 BM25 在詐欺查詢上的效能",
@@ -162,8 +165,8 @@ class GeminiMCPAgent:
 如果不需要使用工具：
 {{"action": "respond", "response": "你的回答"}}
 
-例子：
-- 使用者問「詐欺資料集有多少筆資料？」→ {{"action": "use_tool", "tool": "read_fraud_data", "args": {{}}, "reasoning": "需要讀取資料集來計算筆數"}}
+- 例子：
+- 使用者問「詐欺資料集有多少筆資料？」→ {{"action": "use_tool", "tool": "read_fraud_data", "args": {"offset": 0, "limit": 0}, "reasoning": "需要讀取資料集來計算筆數"}}
 - 使用者問「什麼是詐欺？」→ {{"action": "respond", "response": "詐欺是指..."}}
 
 請只回傳 JSON，不要包含其他說明文字."""
@@ -288,7 +291,7 @@ class GeminiMCPAgent:
                 return "\n".join(formatted_results)
             
             elif tool_name == "read_fraud_data":
-                return f"📊 詐欺資料集包含 {len(result)} 筆記錄"
+                return f"📊 取得 {len(result)} 筆詐欺資料記錄"
             
             elif tool_name == "evaluate_fraud":
                 return (f"📈 評估結果：\n"

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -74,11 +74,26 @@ with open(_QUERIES_PATH, "r", encoding="utf-8") as f:
 _QRELS = load_qrels(str(_QRELS_PATH))
 
 @mcp.tool()
-def read_fraud_data() -> List[Dict[str, object]]:
-    """Return the fraud judgment summary dataset."""
+def read_fraud_data(offset: int = 0, limit: int | None = None) -> List[Dict[str, object]]:
+    """Return a slice of the fraud judgment summary dataset.
+
+    Parameters
+    ----------
+    offset: int, optional
+        Starting index of records to return. Defaults to ``0``.
+    limit: int | None, optional
+        Maximum number of records to return. ``None`` will return all
+        records after ``offset``.
+    """
     path = _CORPUS_DIR / "fraud_judgment_summary.json"
     with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        data = json.load(f)
+
+    if offset < 0:
+        offset = 0
+    if limit is None or limit <= 0:
+        return data[offset:]
+    return data[offset : offset + limit]
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary
- allow returning a slice of the fraud dataset via `read_fraud_data(offset, limit)`
- document new pagination arguments in README
- update Gemini client descriptions and sample usage

## Testing
- `python -m py_compile mcp_server.py gemini_mcp_client.py bm25_retrieval.py build_bm25_index.py evaluate_bm25.py score.py`

------
https://chatgpt.com/codex/tasks/task_e_684e4f9437748324bd84eabf46d0648c