### PR TITLE
Add simple Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,16 @@ python gemini_mcp_client.py
 ```
 
 `.env` 檔已加入 `.gitignore`，不會被納入版本控管。
+
+## 簡易網頁介面
+
+本專案提供 `web_server.py` 以 Flask 建立簡易的查詢網頁。啟動後即可透過瀏覽器輸入查詢並取得檢索結果。
+
+```bash
+# 安裝相依套件
+pip install -r requirements.txt
+# 啟動伺服器
+python web_server.py
+```
+
+預設會在 <http://localhost:8000/> 提供網頁介面。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 google-generativeai
+flask

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+    <title>Q2D 檢索服務</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        form { margin-bottom: 20px; }
+        #results { white-space: pre-wrap; }
+    </style>
+</head>
+<body>
+    <h1>Q2D 檢索服務</h1>
+    <form id="search-form">
+        <input type="text" id="query" placeholder="輸入查詢字串" size="40" required>
+        <button type="submit">搜尋</button>
+    </form>
+    <div id="results"></div>
+
+    <script>
+    document.getElementById('search-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const query = document.getElementById('query').value.trim();
+        if (!query) return;
+        document.getElementById('results').textContent = '搜尋中...';
+        try {
+            const resp = await fetch('/api/search', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ query })
+            });
+            const data = await resp.json();
+            if (data.error) {
+                document.getElementById('results').textContent = '錯誤：' + data.error;
+            } else {
+                const lines = data.results.map(r => `【${r.doc_id}】分數: ${r.score.toFixed(4)}\n${r.text}\n`);
+                document.getElementById('results').textContent = lines.join('\n');
+            }
+        } catch (err) {
+            document.getElementById('results').textContent = '錯誤：' + err;
+        }
+    });
+    </script>
+</body>
+</html>

--- a/web_server.py
+++ b/web_server.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from flask import Flask, request, jsonify, render_template
+
+from bm25_retrieval import BM25Retriever, load_index, load_corpus
+
+app = Flask(__name__)
+
+# Preload index and corpus for fraud dataset
+_INDEX_PATH = Path(__file__).with_name("fraud_index.json")
+_CORPUS_DIR = Path("data") / "fraud"
+_INDEX = load_index(_INDEX_PATH)
+_BM25 = BM25Retriever(_INDEX)
+_DOCS = {doc["id"]: doc["text"] for doc in load_corpus(str(_CORPUS_DIR))}
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/api/search', methods=['POST'])
+def api_search():
+    data = request.get_json(force=True)
+    query = data.get('query', '').strip()
+    if not query:
+        return jsonify({'error': 'Missing query'}), 400
+    top_k = int(data.get('top_k', 5))
+    results = _BM25.query(query, top_k)
+    formatted = [
+        {"doc_id": doc_id, "score": score, "text": _DOCS.get(doc_id, "")}
+        for score, doc_id in results
+    ]
+    return jsonify({'results': formatted})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- add Flask-based web server and HTML page for querying the dataset
- document how to run the new web interface
- add Flask to requirements

## Testing
- `python -m py_compile web_server.py mcp_server.py bm25_retrieval.py build_bm25_index.py evaluate_bm25.py gemini_mcp_client.py mcp_client.py score.py`

------
https://chatgpt.com/codex/tasks/task_e_684f80707e288324933acadce4172bd1