### PR TITLE
Add agent chat web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,17 @@ python gemini_mcp_client.py
 ```
 
 `.env` 檔已加入 `.gitignore`，不會被納入版本控管。
+
+## 簡易網頁介面
+
+`web_server.py` 提供一個基於 Flask 的聊天頁面，可與 Gemini 智能助手互動。啟動前請先設定 `GEMINI_API_KEY` 環境變數。
+
+```bash
+# 安裝相依套件
+pip install -r requirements.txt
+# 設定金鑰並啟動伺服器
+export GEMINI_API_KEY=your_key
+python web_server.py
+```
+
+啟動後瀏覽 <http://localhost:8000/> 即可進行對話，詢問資料集或搜尋相關問題。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 google-generativeai
+flask

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+    <meta charset="UTF-8">
+<title>Q2D 智能助手</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        #chat-box { border: 1px solid #ccc; padding: 10px; height: 400px; overflow-y: auto; white-space: pre-wrap; }
+        form { margin-top: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Q2D 智能助手</h1>
+    <div id="chat-box"></div>
+    <form id="chat-form">
+        <input type="text" id="message" placeholder="輸入訊息" size="40" required>
+        <button type="submit">送出</button>
+    </form>
+
+    <script>
+    const chatBox = document.getElementById('chat-box');
+    document.getElementById('chat-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const msg = document.getElementById('message').value.trim();
+        if (!msg) return;
+        append('我', msg);
+        document.getElementById('message').value = '';
+        try {
+            const resp = await fetch('/api/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ message: msg })
+            });
+            const data = await resp.json();
+            if (data.error) {
+                append('錯誤', data.error);
+            } else {
+                append('助手', data.response);
+            }
+        } catch (err) {
+            append('錯誤', err);
+        }
+    });
+
+    function append(sender, text) {
+        const p = document.createElement('p');
+        p.textContent = `${sender}: ${text}`;
+        chatBox.appendChild(p);
+        chatBox.scrollTop = chatBox.scrollHeight;
+    }
+    </script>
+</body>
+</html>

--- a/web_server.py
+++ b/web_server.py
@@ -1,0 +1,40 @@
+"""Flask server providing a simple chat interface to the Gemini agent."""
+
+import os
+from flask import Flask, request, jsonify, render_template
+
+from gemini_mcp_client import GeminiMCPAgent
+from mcp_client import MCPClient
+
+app = Flask(__name__)
+
+# Initialize Gemini agent and MCP server
+_API_KEY = os.getenv("GEMINI_API_KEY")
+if not _API_KEY:
+    raise RuntimeError("GEMINI_API_KEY environment variable is required")
+
+_MCP_CLIENT = MCPClient("mcp_server.py")
+_MCP_CLIENT.start()
+_AGENT = GeminiMCPAgent(_API_KEY, _MCP_CLIENT)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/api/chat', methods=['POST'])
+def api_chat():
+    data = request.get_json(force=True)
+    message = data.get('message', '').strip()
+    if not message:
+        return jsonify({'error': 'Missing message'}), 400
+    try:
+        response = _AGENT.chat(message)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+    return jsonify({'response': response})
+
+if __name__ == '__main__':
+    try:
+        app.run(host='0.0.0.0', port=8000)
+    finally:
+        _MCP_CLIENT.stop()


### PR DESCRIPTION
## Summary
- replace search page with chat interface
- new `/api/chat` endpoint that uses `GeminiMCPAgent`
- README instructions updated for agent-based server

## Testing
- `python -m py_compile web_server.py mcp_server.py bm25_retrieval.py build_bm25_index.py evaluate_bm25.py gemini_mcp_client.py mcp_client.py score.py`

------
https://chatgpt.com/codex/tasks/task_e_684f80707e288324933acadce4172bd1