### PR TITLE
Return fraud records in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ uv pip install -r requirements.txt
 預設使用 `gemini-2.0-flash` 模型。建議先使用 `search` 觀察檢索結果，
 若結果不足再呼叫 `expand_search`。呼叫時需提供 `query` 與可選的 `top_k` 參數。
 
-此外，`read_fraud_data` 工具現在支援 `offset` 與 `limit` 參數，可分批取回資料以避免
-一次回傳過多內容造成解析問題。例如：
+此外，`read_fraud_data` 工具會直接回傳資料列表，建議搭配
+`offset` 與 `limit` 參數分批取得結果，以避免一次回傳過多內容造成解析問題。例如：
 
 ```bash
 {"tool": "read_fraud_data", "args": {"offset": 0, "limit": 20}}

--- a/gemini_mcp_client.py
+++ b/gemini_mcp_client.py
@@ -253,7 +253,15 @@ class GeminiMCPAgent:
                 return "\n".join(formatted_results)
             
             elif tool_name == "read_fraud_data":
-                return f"📊 取得 {len(result)} 筆詐欺資料記錄"
+                # The server may return a large list of records. To prevent
+                # overwhelming the model we truncate the output. If the caller
+                # specifies ``limit`` we respect it up to 20 items; otherwise
+                # show the first 20 records by default.
+                limit = args.get("limit", 20)
+                if not isinstance(limit, int) or limit <= 0 or limit > 20:
+                    limit = 20
+                limited = result[:limit]
+                return json.dumps(limited, ensure_ascii=False, indent=2)
             
             elif tool_name == "evaluate_fraud":
                 return (f"📈 評估結果：\n"


### PR DESCRIPTION
## Summary
- return fraud data records in `GeminiMCPAgent._execute_tool`
- document that `read_fraud_data` returns records and should be limited with `offset`/`limit`

## Testing
- `python -m py_compile gemini_mcp_client.py mcp_server.py`

------
https://chatgpt.com/codex/tasks/task_e_684ff69aa9a48324bd1d95d53a180feb