### PR TITLE
Add tool to read fraud queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ uv pip install -r requirements.txt
 {"tool": "read_fraud_data", "args": {"offset": 0, "limit": 20}}
 ```
 
+若需要查看查詢資料，可使用 `read_fraud_queries`，用法同上：
+
+```bash
+{"tool": "read_fraud_queries", "args": {"offset": 0, "limit": 10}}
+```
+
 ## Gemini MCP 客戶端
 
 若要使用 `gemini_mcp_client.py` 啟動智能助手，請先設定 Google Gemini API 金鑰。建議在專案根目錄建立 `.env` 檔並填入：

--- a/gemini_mcp_client.py
+++ b/gemini_mcp_client.py
@@ -85,6 +85,13 @@ class GeminiMCPAgent:
                     "limit": "最多返回的筆數，預設為全部"
                 }
             },
+            "read_fraud_queries": {
+                "description": "讀取詐欺查詢資料，可指定 offset 與 limit",
+                "parameters": {
+                    "offset": "起始索引，預設 0",
+                    "limit": "最多返回的筆數，預設為全部"
+                }
+            },
             "evaluate_fraud": {
                 "description": "評估 BM25 在詐欺查詢上的效能",
                 "parameters": {
@@ -105,6 +112,7 @@ class GeminiMCPAgent:
         json_example_2 = '{"action": "respond", "response": "你的回答"}'
         json_example_3 = '{"action": "use_tool", "tool": "read_fraud_data", "args": {"offset": 0, "limit": 0}, "reasoning": "需要讀取資料集來計算筆數"}'
         json_example_4 = '{"action": "respond", "response": "詐欺是指..."}'
+        json_example_5 = '{"action": "use_tool", "tool": "read_fraud_queries", "args": {"offset": 0, "limit": 5}, "reasoning": "查看範例查詢"}'
 
         return f"""你是一個智能助手，可以幫助使用者查詢和分析詐欺相關資料。
 
@@ -124,6 +132,7 @@ class GeminiMCPAgent:
 - 例子：
 - 使用者問「詐欺資料集有多少筆資料？」→ {json_example_3}
 - 使用者問「什麼是詐欺？」→ {json_example_4}
+- 使用者問「可以列出查詢範例嗎？」→ {json_example_5}
 
 請只回傳 JSON，不要包含其他說明文字."""
 
@@ -257,6 +266,13 @@ class GeminiMCPAgent:
                 # overwhelming the model we truncate the output. If the caller
                 # specifies ``limit`` we respect it up to 20 items; otherwise
                 # show the first 20 records by default.
+                limit = args.get("limit", 20)
+                if not isinstance(limit, int) or limit <= 0 or limit > 20:
+                    limit = 20
+                limited = result[:limit]
+                return json.dumps(limited, ensure_ascii=False, indent=2)
+
+            elif tool_name == "read_fraud_queries":
                 limit = args.get("limit", 20)
                 if not isinstance(limit, int) or limit <= 0 or limit > 20:
                     limit = 20

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -97,6 +97,16 @@ def read_fraud_data(offset: int = 0, limit: int | None = None) -> List[Dict[str,
 
 
 @mcp.tool()
+def read_fraud_queries(offset: int = 0, limit: int | None = None) -> List[Dict[str, object]]:
+    """Return a slice of the fraud queries dataset."""
+    if offset < 0:
+        offset = 0
+    if limit is None or limit <= 0:
+        return _QUERIES[offset:]
+    return _QUERIES[offset : offset + limit]
+
+
+@mcp.tool()
 def test() -> str:
     """Check if the server is running."""
     return "Q2D search server is running"


### PR DESCRIPTION
## Summary
- add `read_fraud_queries` tool to the MCP server
- expose the new tool in `GeminiMCPAgent`
- show example usage in README

## Testing
- `python -m py_compile mcp_server.py gemini_mcp_client.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_684ffb6496308324a22e143bcefd5d3b