### PR TITLE
Add MCP-based keyword tuning agent

### DIFF
--- a/keyword_tuning_agent.py
+++ b/keyword_tuning_agent.py
@@ -1,0 +1,86 @@
+"""Keyword tuning agent using the MCP server tools.
+
+This script evaluates retrieval metrics on the first three fraud queries using
+BM25 search provided by the MCP server. It first issues the original queries
+via the ``search`` tool and then tries the ``expand_search`` tool to expand the
+query through Gemini. Accuracy and MRR are reported before and after expansion.
+"""
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from mcp_client import MCPClient
+from score import load_qrels, compute_scores
+
+DATA_DIR = Path("data") / "fraud" / "format"
+QUERIES_PATH = DATA_DIR / "queries.json"
+QRELS_PATH = DATA_DIR / "qrels.json"
+
+TOP_K = 5
+NUM_QUERIES = 3
+
+
+def load_queries() -> List[Dict[str, object]]:
+    with open(QUERIES_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def run_search(client: MCPClient, query: str) -> List[int]:
+    resp = client.call_tool("search", {"query": query, "top_k": TOP_K})
+    if "error" in resp:
+        raise RuntimeError(resp["error"])
+    return [item["doc_id"] for item in resp["result"]]
+
+
+def run_expand_search(client: MCPClient, query: str) -> Tuple[str, List[int]]:
+    resp = client.call_tool("expand_search", {"query": query, "top_k": TOP_K})
+    if "error" in resp:
+        # Gemini might be unavailable; fall back to original query
+        expanded_query = query
+        docs = run_search(client, query)
+    else:
+        result = resp["result"]
+        expanded_query = result.get("expanded_query", query)
+        docs = [item["doc_id"] for item in result.get("results", [])]
+    return expanded_query, docs
+
+
+def main() -> None:
+    queries = load_queries()
+    qrels = load_qrels(str(QRELS_PATH))
+
+    preds_before: Dict[int, List[int]] = {}
+    preds_after: Dict[int, List[int]] = {}
+    expansions: Dict[int, Tuple[str, str]] = {}
+
+    with MCPClient("mcp_server.py") as client:
+        for q in queries[:NUM_QUERIES]:
+            qid = q["id"]
+            text = q["text"]
+
+            preds_before[qid] = run_search(client, text)
+            expanded, docs = run_expand_search(client, text)
+            preds_after[qid] = docs
+            expansions[qid] = (text, expanded)
+
+    # Only evaluate the queries we processed
+    subset_qrels = {qid: qrels[qid] for qid in preds_before.keys() if qid in qrels}
+
+    acc_before, mrr_before = compute_scores(subset_qrels, preds_before)
+    acc_after, mrr_after = compute_scores(subset_qrels, preds_after)
+
+    print("Original metrics:")
+    print(f"  Accuracy: {acc_before:.4f}, MRR: {mrr_before:.4f}")
+    print("Expanded metrics:")
+    print(f"  Accuracy: {acc_after:.4f}, MRR: {mrr_after:.4f}")
+    print()
+    for qid, (orig, expanded) in expansions.items():
+        print(f"Query {qid}")
+        print(f"  Original : {orig}")
+        print(f"  Expanded : {expanded}")
+        print("-" * 40)
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -3,7 +3,10 @@ import os
 from pathlib import Path
 from typing import List, Dict
 import sys
-import google.generativeai as genai
+try:
+    import google.generativeai as genai
+except Exception:  # pragma: no cover - optional dependency
+    genai = None
 
 from bm25_retrieval import BM25Retriever, load_index, load_corpus
 from score import load_qrels, compute_scores
@@ -61,7 +64,7 @@ _QRELS_PATH = _CORPUS_DIR / "format" / "qrels.json"
 # Configure Gemini model for query expansion
 _GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 _GEMINI_MODEL = None
-if _GEMINI_API_KEY:
+if _GEMINI_API_KEY and genai is not None:
     try:
         genai.configure(api_key=_GEMINI_API_KEY)
         _GEMINI_MODEL = genai.GenerativeModel("gemini-2.0-flash")


### PR DESCRIPTION
## Summary
- integrate `keyword_tuning_agent.py` with MCP tools
- make `mcp_server.py` optional if Google API isn't installed

## Testing
- `pytest -q`
- `python keyword_tuning_agent.py | head -n 6`


------
https://chatgpt.com/codex/tasks/task_e_6853c98478808324a9ce227796ce23c4